### PR TITLE
feat: add axum feature flag and optional dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,124 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+dependencies = [
+ "axum-core 0.5.2",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-tracing-opentelemetry"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd3e188039e0e9e3dce1ad873358fd6bab72e6496e18b898bc36d72c07af4b26"
+dependencies = [
+ "axum 0.8.4",
+ "futures-core",
+ "futures-util",
+ "http",
+ "opentelemetry",
+ "pin-project-lite",
+ "tower 0.5.2",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-opentelemetry-instrumentation-sdk",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,17 +478,25 @@ dependencies = [
 name = "dogdata"
 version = "0.2.1"
 dependencies = [
+ "axum 0.7.9",
+ "axum-tracing-opentelemetry",
  "chrono",
+ "futures-util",
+ "http",
  "opentelemetry",
  "opentelemetry-datadog",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
+ "pin-project-lite",
  "reqwest",
  "serde",
  "serde_json",
+ "tokio",
+ "tower 0.4.13",
  "tracing",
  "tracing-appender",
  "tracing-opentelemetry",
+ "tracing-opentelemetry-instrumentation-sdk",
  "tracing-serde",
  "tracing-subscriber",
 ]
@@ -396,7 +522,7 @@ dependencies = [
  "async-trait",
  "getrandom 0.2.16",
  "http",
- "matchit",
+ "matchit 0.8.4",
  "opentelemetry",
  "opentelemetry_sdk",
  "reqwest",
@@ -1146,9 +1272,15 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.8.6"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f926ade0c4e170215ae43342bf13b9310a437609c81f29f86c5df6657582ef9"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -1759,7 +1891,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
- "tower",
+ "tower 0.5.2",
  "tower-http",
  "tower-service",
  "url",
@@ -1968,6 +2100,16 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -2541,6 +2683,17 @@ dependencies = [
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
@@ -2552,6 +2705,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2567,7 +2721,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -2656,6 +2810,18 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry-instrumentation-sdk"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dda3080d8657b99ddd303a4bda25ebd3479820abbd5a67af70a9dafd06b1713"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "tracing",
+ "tracing-opentelemetry",
 ]
 
 [[package]]

--- a/crates/dogdata/Cargo.toml
+++ b/crates/dogdata/Cargo.toml
@@ -13,6 +13,16 @@ categories = ["development-tools::debugging"]
 
 [features]
 default = []
+axum = [
+    "dep:axum", 
+    "dep:http", 
+    "dep:tower", 
+    "dep:pin-project-lite", 
+    "dep:tokio", 
+    "dep:futures-util", 
+    "dep:tracing-opentelemetry-instrumentation-sdk", 
+    "dep:axum-tracing-opentelemetry"
+]
 
 [dependencies]
 # OpenTelemetry
@@ -39,3 +49,13 @@ serde_json = { workspace = true }
 
 # Misc
 chrono = "^0.4.33"
+
+# Axum feature dependencies
+axum = { version = "0.7", optional = true }
+http = { version = "1.0", optional = true }
+tower = { version = "0.4", optional = true }
+pin-project-lite = { version = "0.2", optional = true }
+tokio = { version = "1.0", features = ["signal", "macros"], optional = true }
+futures-util = { version = "0.3", optional = true }
+tracing-opentelemetry-instrumentation-sdk = { version = "0.29", optional = true }
+axum-tracing-opentelemetry = { version = "0.29", optional = true }

--- a/crates/dogdata/src/axum/http_server.rs
+++ b/crates/dogdata/src/axum/http_server.rs
@@ -1,0 +1,106 @@
+// MIT License
+//
+// Copyright (c) 2023 willbank
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//
+//! `OpenTelemetry` http_server helper functions. Copied from [axum-tracing-opentelemetry v0.16](https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/blob/0.16.0/axum-tracing-opentelemetry/src/middleware/trace_extractor.rs)
+//!
+use std::error::Error;
+
+use tracing::field::Empty;
+use tracing_opentelemetry_instrumentation_sdk::http::{
+    http_flavor, http_host, http_method, url_scheme, user_agent,
+};
+use tracing_opentelemetry_instrumentation_sdk::TRACING_TARGET;
+
+pub fn make_span_from_request<B>(req: &http::Request<B>) -> tracing::Span {
+    // [opentelemetry-specification/.../http.md](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md)
+    // [opentelemetry-specification/.../span-general.md](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md)
+    // Can not use const or opentelemetry_semantic_conventions::trace::* for name of records
+    let http_method = http_method(req.method());
+    tracing::trace_span!(
+        target: TRACING_TARGET,
+        "HTTP request",
+        http.request.method = %http_method,
+        http.route = Empty, // to set by router of "webframework" after
+        network.protocol.version = %http_flavor(req.version()),
+        server.address = http_host(req),
+        // server.port = req.uri().port(),
+        http.client.address = Empty, //%$request.connection_info().realip_remote_addr().unwrap_or(""),
+        user_agent.original = user_agent(req),
+        http.response.status_code = Empty, // to set on response
+        http.status_code = Empty, // to set on response (datadog attribute)
+        url.path = req.uri().path(),
+        url.query = req.uri().query(),
+        url.scheme = url_scheme(req.uri()),
+        otel.name = %http_method, // to set by router of "webframework" after
+        otel.kind = ?opentelemetry::trace::SpanKind::Server,
+        otel.status_code = Empty, // to set on response
+        trace_id = Empty, // to set on response
+        request_id = Empty, // to set
+        exception.message = Empty, // to set on response
+        "span.type" = "web", // non-official open-telemetry key, only supported by Datadog
+    )
+}
+
+pub fn update_span_from_response<B>(span: &tracing::Span, response: &http::Response<B>) {
+    let status = response.status();
+    span.record("http.response.status_code", status.as_u16());
+    span.record("http.status_code", status.as_u16());
+
+    if status.is_server_error() {
+        span.record("otel.status_code", "ERROR");
+        // see[](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.22.0/specification/trace/semantic_conventions/http.md#status)
+        // Span Status MUST be left unset if HTTP status code was in the 1xx, 2xx or 3xx ranges,
+        // unless there was another error (e.g., network error receiving the response body;
+        // or 3xx codes with max redirects exceeded), in which case status MUST be set to Error.
+        // } else {
+        //     span.record("otel.status_code", "OK");
+    }
+}
+
+pub fn update_span_from_error<E>(span: &tracing::Span, error: &E)
+where
+    E: Error,
+{
+    span.record("otel.status_code", "ERROR");
+    //span.record("http.status_code", 500);
+    span.record("exception.message", error.to_string());
+    error
+        .source()
+        .map(|s| span.record("exception.message", s.to_string()));
+}
+
+pub fn update_span_from_response_or_error<B, E>(
+    span: &tracing::Span,
+    response: &Result<http::Response<B>, E>,
+) where
+    E: Error,
+{
+    match response {
+        Ok(response) => {
+            update_span_from_response(span, response);
+        }
+        Err(err) => {
+            update_span_from_error(span, err);
+        }
+    }
+}

--- a/crates/dogdata/src/axum/middleware.rs
+++ b/crates/dogdata/src/axum/middleware.rs
@@ -1,0 +1,200 @@
+// MIT License
+//
+// Copyright (c) 2023 willbank
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//
+//! `OpenTelemetry` tracing middleware. Copied from [axum-tracing-opentelemetry v0.16](https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/blob/0.16.0/axum-tracing-opentelemetry/src/middleware/trace_extractor.rs)
+//!
+//! This returns a [`OtelAxumLayer`] configured to use [`OpenTelemetry`'s conventional span field
+//! names][otel].
+//!
+//! # Span fields
+//!
+//! Try to provide some of the field define at
+//! [opentelemetry-specification/.../http.md](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md)
+//! (Please report or provide fix for missing one)
+//!
+//! # Example
+//!
+//! ```
+//! use axum::{Router, routing::get, http::Request};
+//! use axum_tracing_opentelemetry::middleware::OtelAxumLayer;
+//! use std::net::SocketAddr;
+//! use tower::ServiceBuilder;
+//!
+//! let app = Router::new()
+//!     .route("/", get(|| async {}))
+//!     .layer(OtelAxumLayer::default());
+//!
+//! # async {
+//! let addr = &"0.0.0.0:3000".parse::<SocketAddr>().unwrap();
+//! let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+//! axum::serve(listener, app.into_make_service())
+//!     .await
+//!     .expect("server failed");
+//! # };
+//! ```
+//!
+
+use axum::extract::MatchedPath;
+use http::{Request, Response};
+use pin_project_lite::pin_project;
+use std::{
+    error::Error,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower::{Layer, Service};
+use tracing::Span;
+use tracing_opentelemetry_instrumentation_sdk::http as otel_http;
+
+use crate::axum::http_server;
+
+#[deprecated(
+    since = "0.12.0",
+    note = "keep for transition, replaced by OtelAxumLayer"
+)]
+#[must_use]
+pub fn opentelemetry_tracing_layer() -> OtelAxumLayer {
+    OtelAxumLayer::default()
+}
+
+pub type Filter = fn(&str) -> bool;
+
+/// layer/middleware for axum:
+///
+/// - propagate `OpenTelemetry` context (`trace_id`,...) to server
+/// - create a Span for `OpenTelemetry` (and tracing) on call
+///
+/// `OpenTelemetry` context are extracted from tracing's span.
+#[derive(Default, Debug, Clone)]
+pub struct OtelAxumLayer {
+    filter: Option<Filter>,
+}
+
+// add a builder like api
+impl OtelAxumLayer {
+    #[must_use]
+    pub fn filter(self, filter: Filter) -> Self {
+        OtelAxumLayer {
+            filter: Some(filter),
+        }
+    }
+}
+
+impl<S> Layer<S> for OtelAxumLayer {
+    /// The wrapped service
+    type Service = OtelAxumService<S>;
+    fn layer(&self, inner: S) -> Self::Service {
+        OtelAxumService {
+            inner,
+            filter: self.filter,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OtelAxumService<S> {
+    inner: S,
+    filter: Option<Filter>,
+}
+
+impl<S, B, B2> Service<Request<B>> for OtelAxumService<S>
+where
+    S: Service<Request<B>, Response = Response<B2>> + Clone + Send + 'static,
+    S::Error: Error + 'static, //fmt::Display + 'static,
+    S::Future: Send + 'static,
+    B: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    // #[allow(clippy::type_complexity)]
+    // type Future = futures_core::future::BoxFuture<'static, Result<Self::Response, Self::Error>>;
+    type Future = ResponseFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        use tracing_opentelemetry::OpenTelemetrySpanExt;
+        let req = req;
+        let span = if self.filter.map_or(true, |f| f(req.uri().path())) {
+            let span = http_server::make_span_from_request(&req);
+
+            let route = http_route(&req);
+            let method = otel_http::http_method(req.method());
+
+            span.record("http.route", route);
+            span.record("otel.name", format!("{method} {route}").trim());
+
+            span.set_parent(otel_http::extract_context(req.headers()));
+            span
+        } else {
+            tracing::Span::none()
+        };
+        let future = {
+            let _ = span.enter();
+            self.inner.call(req)
+        };
+        ResponseFuture {
+            inner: future,
+            span,
+        }
+    }
+}
+
+pin_project! {
+    /// Response future for [`Trace`].
+    ///
+    /// [`Trace`]: super::Trace
+    pub struct ResponseFuture<F> {
+        #[pin]
+        pub(crate) inner: F,
+        pub(crate) span: Span,
+        // pub(crate) start: Instant,
+    }
+}
+
+impl<Fut, ResBody, E> Future for ResponseFuture<Fut>
+where
+    Fut: Future<Output = Result<Response<ResBody>, E>>,
+    E: std::error::Error + 'static,
+{
+    type Output = Result<Response<ResBody>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let _guard = this.span.enter();
+        let result = futures_util::ready!(this.inner.poll(cx));
+        http_server::update_span_from_response_or_error(this.span, &result);
+
+        Poll::Ready(result)
+    }
+}
+
+#[inline]
+fn http_route<B>(req: &Request<B>) -> &str {
+    req.extensions()
+        .get::<MatchedPath>()
+        .map_or_else(|| "", |mp| mp.as_str())
+}

--- a/crates/dogdata/src/axum/mod.rs
+++ b/crates/dogdata/src/axum/mod.rs
@@ -20,16 +20,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-//! Utilities to integrate Rust services with Datadog using [`opentelemetry`],
-//! [`tracing`], and other open source libraries.
+//! Axum utilities.
+//!
+//! Re-exposes the middleware layer OtelInResponseLayer provided by the [`axum-tracing-opentelemetry`] project
+//! (https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk).
+//!
+//! Also, exposes OtelAxumLayer from the same project, but hacked to support datadog.
+//!
+//! Additionally, a shutdown helper function named `shutdown_signal` is also exposed
 
-pub mod formatter;
-pub mod init;
-pub mod model;
-pub mod shutdown;
-pub mod tracer;
+mod shutdown;
+pub use shutdown::*;
 
-#[cfg(feature = "axum")]
-pub mod axum;
+// Exposes OtelAxumLayer and opentelemetry_tracing_layer
+mod middleware;
+pub use middleware::*;
 
-pub use init::init;
+pub use axum_tracing_opentelemetry::middleware::OtelInResponseLayer;
+
+mod http_server;


### PR DESCRIPTION
- Add axum feature flag to conditionally enable axum functionality
- Include all required dependencies: axum, http, tower, pin-project-lite, tokio, futures-util, tracing-opentelemetry-instrumentation-sdk, axum-tracing-opentelemetry
- Update lib.rs to conditionally compile axum module with cfg feature gate
- Ensure base crate compiles without axum dependencies when feature is disabled